### PR TITLE
Adding ability to get back http status code and content via stream requests on errors

### DIFF
--- a/src/Httprequest.php
+++ b/src/Httprequest.php
@@ -411,7 +411,7 @@ class Httprequest {
      */
     final public function setIgnoreErrors($ignore = true) {
 
-        $this->ignore_erors = $ignore;
+        $this->ignore_erors = (bool)$ignore;
 
         return $this;
 

--- a/src/Httprequest.php
+++ b/src/Httprequest.php
@@ -411,7 +411,7 @@ class Httprequest {
      */
     final public function setIgnoreErrors($ignore = true) {
 
-        $this->ignore_erors = (bool)$ignore;
+        $this->ignore_errors = (bool)$ignore;
 
         return $this;
 

--- a/src/Httprequest.php
+++ b/src/Httprequest.php
@@ -157,6 +157,13 @@ class Httprequest {
     private $ch = false;
 
     private $stream_get_data = null;
+
+    /**
+     * Ignore Errors (stream only)
+     *
+     * @var boolean
+     */
+    private $ignore_errors = false;
     
     /**
      * Class constructor
@@ -390,6 +397,21 @@ class Httprequest {
         }
 
         $this->method = $method;
+
+        return $this;
+
+    }
+
+    /**
+     * Set whether or not to ignore errors
+     *
+     * @param   boolean $ignore    Should stream ignore errors
+     *
+     * @return  \Comodojo\Httprequest\Httprequest
+     */
+    final public function setIgnoreErrors($ignore = true) {
+
+        $this->ignore_erors = $ignore;
 
         return $this;
 
@@ -818,6 +840,10 @@ class Httprequest {
 
         if ( $this->authenticationMethod == "BASIC" ) array_push($stream_options['http']['header'], 'Authorization: Basic  '.base64_encode($this->user.":".$this->pass));
         
+        if ( $this->ignore_errors ) {
+            $stream_options['http']['ignore_errors'] = true;
+        }
+
         foreach ( $this->getHeaders() as $header => $value ) {
 
             if ( is_null($value) ) array_push($stream_options['http']['header'], $header);


### PR DESCRIPTION
Hello,

I started using your httprequest class recently and needed to be able to have stream errors return the actual http status code and content (if available). To that end I added an option to set the ignore_errors http option which, when enabled, will cause the user to receive the http status code from the server along with any payload... which is very useful when pulling down data from apis that will return helpful error information when something is wrong.

This is my first ever pull request... so if I did something wrong, should be doing something different, etc. please feel free to let me know.

I set sane defaults (false) to ensure that anyone already using this via streams will have no changes to how things work.

Anywise I'm hoping you will incorporate this into your project and that others might find it of use.